### PR TITLE
delete the onBlur event as it prevents firing the onChange event

### DIFF
--- a/src/Autocomplete.tsx
+++ b/src/Autocomplete.tsx
@@ -211,11 +211,6 @@ export default function Autocomplete<ItemT>(
     setInputValue(v);
     onChangeText?.(v);
   };
-  const blur = (_: NativeSyntheticEvent<TextInputFocusEventData>) => {
-    // console.log('blur', e);
-    // setVisible(false);
-    setFocused(false);
-  };
   const focus = (_: NativeSyntheticEvent<TextInputFocusEventData>) => {
     setVisible(true);
     setFocused(true);
@@ -440,7 +435,6 @@ export default function Autocomplete<ItemT>(
       >
         <TextInput
           ref={inputRef}
-          onBlur={blur}
           onFocus={focus}
           blurOnSubmit={false}
           value={hasMultipleValue || inputValue.length > 0 ? ' ' : ''}


### PR DESCRIPTION
fix #24

The onBlur event is taking precedence over when pressing a new value in the selection list.
Without the event, the onChange event is fired and the autocomplete still behaves normally.

Usage in react-native-web